### PR TITLE
Olympian stats endpoint returns aggregate statistics

### DIFF
--- a/app/controllers/api/v1/olympian_stats_controller.rb
+++ b/app/controllers/api/v1/olympian_stats_controller.rb
@@ -1,9 +1,15 @@
 class Api::V1::OlympianStatsController < ApplicationController
 
   def show
-    fetch_olympian_stats = OlympianStatsAggregator.new(Olympian.all)
-    response = { olympian_stats: fetch_olympian_stats }
-    render json: response, status: 200
+    olympians = Olympian.all
+    if olympians.count > 0
+      fetch_olympian_stats = OlympianStatsAggregator.new(olympians)
+      response = { olympian_stats: fetch_olympian_stats }
+      render json: response, status: 200
+    else
+      response = { error: "Not enough olympians for statistics"}
+      render json: response, status: 404
+    end
   end
 
 end

--- a/app/controllers/api/v1/olympian_stats_controller.rb
+++ b/app/controllers/api/v1/olympian_stats_controller.rb
@@ -1,0 +1,9 @@
+class Api::V1::OlympianStatsController < ApplicationController
+
+  def show
+    fetch_olympian_stats = OlympianStatsAggregator.new(Olympian.all)
+    response = { olympian_stats: fetch_olympian_stats.full_stats }
+    render json: response, status: 200
+  end
+
+end

--- a/app/controllers/api/v1/olympian_stats_controller.rb
+++ b/app/controllers/api/v1/olympian_stats_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::OlympianStatsController < ApplicationController
 
   def show
     fetch_olympian_stats = OlympianStatsAggregator.new(Olympian.all)
-    response = { olympian_stats: fetch_olympian_stats.full_stats }
+    response = { olympian_stats: fetch_olympian_stats }
     render json: response, status: 200
   end
 

--- a/app/models/average_weight.rb
+++ b/app/models/average_weight.rb
@@ -1,0 +1,11 @@
+class AverageWeight
+
+  attr_reader :unit, :male_olympians, :female_olympians
+
+  def initialize(olympians)
+    @unit = "kg"
+    @male_olympians = olympians.average_weight_male
+    @female_olympians = olympians.average_weight_female
+  end
+  
+end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -14,4 +14,20 @@ class Olympian < ApplicationRecord
   def self.find_oldest
     [ select("*, MAX(age)").group(:id).order(age: :desc).first ]
   end
+
+  def self.total_competing_olympians
+    count
+  end
+
+  def self.average_age
+    average(:age).round(0).to_i
+  end
+
+  def self.average_weight_male
+    where(sex: "M").average(:weight).round(1).to_f
+  end
+
+  def self.average_weight_female
+    where(sex: "F").average(:weight).round(1).to_f
+  end
 end

--- a/app/serializers/olympian_stats_aggregator.rb
+++ b/app/serializers/olympian_stats_aggregator.rb
@@ -5,16 +5,9 @@ class OlympianStatsAggregator
 
   def initialize(olympians)
     @total_competing_olympians = olympians.total_competing_olympians
-    @average_weight = average_weight(olympians)
+    @average_weight = AverageWeight.new(olympians)
     @average_age = olympians.average_age
 
-  end
-
-  def average_weight(olympians)
-    { unit: 'kg',
-      male_olympians: olympians.average_weight_male,
-      female_olympians: olympians.average_weight_female
-    }
   end
 
 end

--- a/app/serializers/olympian_stats_aggregator.rb
+++ b/app/serializers/olympian_stats_aggregator.rb
@@ -1,17 +1,20 @@
 class OlympianStatsAggregator
+  attr_reader :total_competing_olympians,
+              :average_weight,
+              :average_age
 
   def initialize(olympians)
-    @olympians = olympians
+    @total_competing_olympians = olympians.total_competing_olympians
+    @average_weight = average_weight(olympians)
+    @average_age = olympians.average_age
+
   end
 
-  def full_stats
-    {
-      total_competing_olympians: @olympians.total_competing_olympians,
-      average_weight: { unit: 'kg',
-                        male_olympians: @olympians.average_weight_male,
-                        female_olympians: @olympians.average_weight_female
-                      },
-      average_age: @olympians.average_age
+  def average_weight(olympians)
+    { unit: 'kg',
+      male_olympians: olympians.average_weight_male,
+      female_olympians: olympians.average_weight_female
     }
   end
+
 end

--- a/app/serializers/olympian_stats_aggregator.rb
+++ b/app/serializers/olympian_stats_aggregator.rb
@@ -1,0 +1,30 @@
+class OlympianStatsAggregator
+
+  def initialize(olympians)
+    @olympians = olympians
+  end
+
+  def total_competing_olympians
+    @olympians.count
+  end
+
+  def average_age
+    @olympians.average(:age).round(0)
+  end
+
+  def average_weight
+    {
+      unit: "kg",
+      male_olympians: @olympians.where(sex: "M").average(:weight).round(1),
+      female_olympians: @olympians.where(sex: "F").average(:weight).round(1)
+    }
+  end
+
+  def full_stats
+    {
+      total_competing_olympians: total_competing_olympians,
+      average_weight: average_weight,
+      average_age: average_age
+    }
+  end
+end

--- a/app/serializers/olympian_stats_aggregator.rb
+++ b/app/serializers/olympian_stats_aggregator.rb
@@ -4,27 +4,14 @@ class OlympianStatsAggregator
     @olympians = olympians
   end
 
-  def total_competing_olympians
-    @olympians.count
-  end
-
-  def average_age
-    @olympians.average(:age).round(0)
-  end
-
-  def average_weight
-    {
-      unit: "kg",
-      male_olympians: @olympians.where(sex: "M").average(:weight).round(1),
-      female_olympians: @olympians.where(sex: "F").average(:weight).round(1)
-    }
-  end
-
   def full_stats
     {
-      total_competing_olympians: total_competing_olympians,
-      average_weight: average_weight,
-      average_age: average_age
+      total_competing_olympians: @olympians.total_competing_olympians,
+      average_weight: { unit: 'kg',
+                        male_olympians: @olympians.average_weight_male,
+                        female_olympians: @olympians.average_weight_female
+                      },
+      average_age: @olympians.average_age
     }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get '/olympians', to: 'olympians#index'
+      get '/olympian_stats', to: 'olympian_stats#show'
     end
   end
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -29,5 +29,18 @@ RSpec.describe Olympian, type: :model do
       expect(youngest_in_array.first.name).to eq "Julie Brougham"
       expect(youngest_in_array.first.age).to eq 62
     end
+
+    it 'counts the olympians' do
+      expect(Olympian.total_competing_olympians).to eq 2850
+    end
+
+    it 'finds the average age of all olympians' do
+      expect(Olympian.average_age).to eq 26
+    end
+
+    it 'finds the average weight by gender' do
+      expect(Olympian.average_weight_male).to eq 77.9
+      expect(Olympian.average_weight_female).to eq 61.4
+    end
   end
 end

--- a/spec/requests/api/v1/olympian_stats_request_spec.rb
+++ b/spec/requests/api/v1/olympian_stats_request_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe 'Olympians Stats API', :type => :request do
+  describe 'get olympian_stats endpoint' do
+    it 'gets olympian_stats successfully' do
+      get '/api/v1/olympian_stats'
+      expect(response).to be_successful
+      parsed_response = JSON.parse(response.body, symbolize_names: true)
+
+      expect(parsed_response).to have_key :olympian_stats
+      expect(parsed_response[:olympian_stats]).to have_key :total_competing_olympians
+      expect(parsed_response[:olympian_stats]).to have_key :average_weight
+      expect(parsed_response[:olympian_stats][:average_weight]).to have_key :unit
+      expect(parsed_response[:olympian_stats][:average_weight]).to have_key :male_olympians
+      expect(parsed_response[:olympian_stats][:average_weight]).to have_key :female_olympians
+      expect(parsed_response[:olympian_stats]).to have_key :average_age
+    end
+  end
+end

--- a/spec/requests/api/v1/olympian_stats_request_spec.rb
+++ b/spec/requests/api/v1/olympian_stats_request_spec.rb
@@ -15,5 +15,15 @@ RSpec.describe 'Olympians Stats API', :type => :request do
       expect(parsed_response[:olympian_stats][:average_weight]).to have_key :female_olympians
       expect(parsed_response[:olympian_stats]).to have_key :average_age
     end
+
+    it 'renders error message if no Olympians in db' do
+      allow(Olympian).to receive(:all) { [] }
+      get '/api/v1/olympian_stats'
+      expect(response.status).to eq 404
+      parsed_response = JSON.parse(response.body, symbolize_names: true)
+
+      expect(parsed_response).to have_key :error
+
+    end
   end
 end


### PR DESCRIPTION
**What it does**

Creates an endpoint for `olympian_statistics` that returns stats of all olympians in the db. Does not return stats if there are no olympians in db.

Several model methods to query for particular statistics. New classes created to aggregate those methods together.

**Where to start**
`app/serializers/olympian_stats_aggregator.rb` is invoked in the controller

Closes #8