### PR TITLE
Remove fastjson_api serializer and use custom objects for get olympians

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'json'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
-gem 'fast_jsonapi'
+# gem 'fast_jsonapi'
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 gem 'activerecord-import'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,8 +56,6 @@ GEM
     diff-lcs (1.3)
     docile (1.3.2)
     erubi (1.9.0)
-    fast_jsonapi (1.5)
-      activesupport (>= 4.2)
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -171,7 +169,6 @@ DEPENDENCIES
   awesome_print
   bootsnap (>= 1.1.0)
   byebug
-  fast_jsonapi
   json
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/api/v1/olympians_controller.rb
+++ b/app/controllers/api/v1/olympians_controller.rb
@@ -4,9 +4,7 @@ class Api::V1::OlympiansController < ApplicationController
     olympians = fetch_olympians(params[:age])
 
     if olympians.count > 0
-      olympians_serialized = OlympianSerializer.new(olympians)
-      olympians_as_hash = ReformatOlympians.new(olympians_serialized.serializable_hash)
-
+      olympians_as_hash = { olympians: OlympianAggregator.build(olympians) }
       render json: olympians_as_hash, status: 200
     else
       response_hash = { olympians: []}
@@ -18,7 +16,7 @@ class Api::V1::OlympiansController < ApplicationController
   def fetch_olympians(age_param)
     case age_param
     when nil
-      Olympian.all
+      Olympian.includes(:olympian_events).all
     when 'youngest'
       Olympian.find_youngest
     when 'oldest'

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -6,6 +6,9 @@ class Olympian < ApplicationRecord
   belongs_to :country
   belongs_to :sport
 
+  def medals_won
+    olympian_events.where(medal: [1, 2, 3]).count
+  end
 
   def self.find_youngest
     [ select("*, MIN(age)").group(:id).order(:age).first ]

--- a/app/serializers/olympian_aggregator.rb
+++ b/app/serializers/olympian_aggregator.rb
@@ -1,0 +1,8 @@
+class OlympianAggregator
+
+  def self.build(olympians)
+    olympians.map do |olympian|
+      OlympianSerializer.new(olympian)
+    end
+  end
+end

--- a/app/serializers/olympian_serializer.rb
+++ b/app/serializers/olympian_serializer.rb
@@ -1,17 +1,12 @@
 class OlympianSerializer
-  include FastJsonapi::ObjectSerializer
-  attributes :name, :age, :team, :sport, :total_medals_won
+  attr_reader :name, :age, :team, :sport, :total_medals_won
 
-  attribute :team do |object|
-    object.country.team
-  end
-
-  attribute :sport do |object|
-    object.sport.sport
-  end
-
-  attribute :total_medals_won do |object|
-    object.olympian_events.where(medal: [1, 2, 3]).count
+  def initialize(olympian)
+    @name = olympian.name
+    @age = olympian.age
+    @team = olympian.country.team
+    @sport = olympian.sport.sport
+    @total_medals_won = olympian.medals_won
   end
 
 end

--- a/spec/models/olympian_spec.rb
+++ b/spec/models/olympian_spec.rb
@@ -52,5 +52,13 @@ RSpec.describe Olympian, type: :model do
       no_medal_guy = Olympian.find_by(name: "Andreea Aanei")
       expect(no_medal_guy.event_medal).to eq "NA"
     end
+
+    it 'returns the count of medals won' do
+      medaled_olympian = Olympian.find_by(name: "Luc Abalo")
+      expect(medaled_olympian.medals_won).to eq 1
+
+      non_medaled_olympian = Olympian.find_by(name: "Andreea Aanei")
+      expect(non_medaled_olympian.medals_won).to eq 0
+    end
   end
 end

--- a/spec/requests/api/v1/olympians_request_spec.rb
+++ b/spec/requests/api/v1/olympians_request_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe 'Olympians API', :type => :request do
     end
 
     it 'returns an empty array for no olympians in db' do
-
-      allow(Olympian).to receive(:all) { [] }
+      allow(Olympian).to receive_message_chain(:includes, :all) { [] }
+      
       get '/api/v1/olympians'
       expect(response).to be_successful
       parsed_response = JSON.parse(response.body, symbolize_names: true)


### PR DESCRIPTION
**What it does**

Refactors the use of the `fastjson_api` serializer into custom objects `OlympianSerializer` and `OlympianAggregator` to build the hash to send as output. 

Also includes eager loading of fetching all olympians with `olympian_events`.

**Where to start**

`app/controllers/api/v1/olympians_controller.rb`

closes #22 